### PR TITLE
In watcher@beta we trust

### DIFF
--- a/elm-watch.json
+++ b/elm-watch.json
@@ -6,5 +6,6 @@
             ],
             "output": "public/main.js"
         }
-    }
+    },
+    "serve": "public/"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "elm-watch": "^1.2.2"
+        "elm-watch": "^2.0.0-beta.6"
       }
     },
     "node_modules/anymatch": {
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/elm-watch": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/elm-watch/-/elm-watch-1.2.2.tgz",
-      "integrity": "sha512-mXus1ThAoDc1P0eW0SDf/5MTqe3cqBrounyBuoFBdYSsDAkHw4HyG7QYc6ShbNjpAbf35gEFPei+vd2ih6f5aw==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/elm-watch/-/elm-watch-2.0.0-beta.6.tgz",
+      "integrity": "sha512-pb3qZVfoBMEWsfrP4mN760z85n5XC0cXg1JRR4ojAVZVjFMeDczYojLaKDQgP+qNeMAK52xj7s31+bCevT+X2Q==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "elm-watch": "^1.2.2"
+    "elm-watch": "^2.0.0-beta.6"
   }
 }


### PR DESCRIPTION
So basically it cried about an extra field `"serve : public/"`, which in case of using watcher@beta would be just okay. So here I changed the package to watcher@beta, and here we go.